### PR TITLE
Add max_portal_remote_users, optionally refusing to join too big Telegram rooms

### DIFF
--- a/mautrix_telegram/config.py
+++ b/mautrix_telegram/config.py
@@ -139,6 +139,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.backfill.disable_notifications")
         copy("bridge.backfill.normal_groups")
         copy("bridge.max_portal_rooms")
+        copy("bridge.max_portal_remote_users")
 
         copy("bridge.initial_power_level_overrides.group")
         copy("bridge.initial_power_level_overrides.user")

--- a/mautrix_telegram/example-config.yaml
+++ b/mautrix_telegram/example-config.yaml
@@ -221,6 +221,8 @@ bridge:
     # The maximum number of rooms that can be bridged on this instance.
     # When the maximum number of rooms has been reached, attempts to create new links will error. Set to -1 to disable.
     max_portal_rooms: -1
+    # The maximum number of Telegram users allowed in a single room
+    max_portal_remote_users: -1
     # Settings for converting animated stickers.
     animated_sticker:
         # Format to which animated stickers should be converted.

--- a/mautrix_telegram/portal/base.py
+++ b/mautrix_telegram/portal/base.py
@@ -290,6 +290,12 @@ class BasePortal(MautrixBasePortal, ABC):
                                                          expire_date=expire, usage_limit=uses))
         return link.link
 
+    async def get_remote_user_count(self, user: 'u.User') -> int:
+        entity = await self.get_entity(user)
+        if not isinstance(entity, (Chat, Channel)):
+            raise ValueError("Can't get remote user count for Portal that isn't Chat nor Channel")
+        return entity.participants_count
+
     # endregion
     # region Matrix room cleanup
 


### PR DESCRIPTION
This still (currently) allows them to organically grow beyond the limit later.

Addresses https://github.com/mautrix/telegram/issues/672