### PR TITLE
Add time_func and time some slow sections of code

### DIFF
--- a/mautrix_telegram/__main__.py
+++ b/mautrix_telegram/__main__.py
@@ -38,6 +38,7 @@ from .portal import Portal, init as init_portal
 from .puppet import Puppet, init as init_puppet
 from .user import User, init as init_user
 from .version import version, linkified_version
+from .util.time_func import time_func
 
 try:
     import prometheus_client as prometheus
@@ -88,6 +89,7 @@ class TelegramBridge(Bridge):
                                    provisioning_api.app)
             context.provisioning_api = provisioning_api
 
+    @time_func(log_level="INFO")
     def prepare_bridge(self) -> None:
         self.bot = init_bot(self.config)
         context = Context(self.az, self.config, self.loop, self.session_container, self, self.bot)
@@ -145,6 +147,7 @@ class TelegramBridge(Bridge):
     async def count_logged_in_users(self) -> int:
         return len([user for user in User.by_tgid.values() if user.tgid])
 
+    @time_func(log_level="DEBUG")
     async def _update_active_puppet_metric(self) -> None:
         active_users = UserActivity.get_active_count(
             self.config['bridge.limits.min_puppet_activity_days'],

--- a/mautrix_telegram/bot.py
+++ b/mautrix_telegram/bot.py
@@ -28,6 +28,8 @@ from telethon.errors import ChannelInvalidError, ChannelPrivateError
 
 from mautrix.types import UserID
 
+from mautrix_telegram.util.time_func import time_func
+
 from .abstract_user import AbstractUser
 from .db import BotChat
 from .types import TelegramID
@@ -87,6 +89,7 @@ class Bot(AbstractUser):
             if isinstance(user_id, int):
                 self.tg_whitelist.append(user_id)
 
+    @time_func(log_level="INFO")
     async def start(self, delete_unless_authenticated: bool = False) -> 'Bot':
         self.chats = {chat.id: chat.type for chat in BotChat.all()}
         await super().start(delete_unless_authenticated)
@@ -95,6 +98,7 @@ class Bot(AbstractUser):
         await self.post_login()
         return self
 
+    @time_func(log_level="INFO")
     async def post_login(self) -> None:
         await self.init_permissions()
         info = await self.client.get_me()

--- a/mautrix_telegram/puppet.py
+++ b/mautrix_telegram/puppet.py
@@ -33,6 +33,7 @@ from mautrix.util.logging import TraceLogger
 from .types import TelegramID
 from .db import Puppet as DBPuppet
 from . import util, portal as p
+from .util.time_func import time_func
 
 if TYPE_CHECKING:
     from .matrix import MatrixHandler
@@ -464,8 +465,8 @@ class Puppet(BasePuppet):
         return None
     # endregion
 
-
-def init(context: 'Context') -> Iterable[Awaitable[Any]]:
+@time_func(log_level="INFO", name="puppet.init")
+def init(context: 'Context') -> "Future[None]":
     global config
     Puppet.az, config, Puppet.loop, _ = context.core
     Puppet.mx = context.mx
@@ -484,4 +485,4 @@ def init(context: 'Context') -> Iterable[Awaitable[Any]]:
                                       in config["bridge.login_shared_secret_map"].items()}
     Puppet.login_device_name = "Telegram Bridge"
 
-    return (puppet.try_start() for puppet in Puppet.all_with_custom_mxid())
+    return asyncio.gather(*(puppet.try_start() for puppet in Puppet.all_with_custom_mxid()))

--- a/mautrix_telegram/util/time_func.py
+++ b/mautrix_telegram/util/time_func.py
@@ -1,0 +1,34 @@
+from asyncio import Future, isfuture
+from functools import wraps
+from time import time
+from types import FunctionType
+from inspect import isawaitable
+import logging
+from typing import Optional
+
+log = logging.getLogger("mau.time_func")
+
+def time_func(log_level: str, name: Optional[str] = None):
+    def decorator(func: FunctionType):
+        @wraps(func)
+        def wrapper_function(*args, **kwargs):
+            int_level = logging.getLevelName(log_level)
+            func_name = name or func.__name__
+            t1 = time()
+            res = func(*args,  **kwargs)
+            print(func_name, res)
+            if isawaitable(res):
+                # Ensure we only log once the function completes
+                async def await_result():
+                    t2 = time()
+                    awaited_res = await res
+                    invocation_time = time() - t1
+                    await_time = time() - t2
+                    log.log(int_level, f"async func {func_name} took {round(invocation_time+await_time, 3)}s (invoke {round(invocation_time, 3)}s, await {round(await_time, 3)})")
+                    return awaited_res
+                return await_result()
+            else:
+                log.log(int_level, f"func {func_name} took {round(time() - t1, 3)}s")
+                return res
+        return wrapper_function
+    return decorator

--- a/mautrix_telegram/util/time_func.py
+++ b/mautrix_telegram/util/time_func.py
@@ -16,7 +16,6 @@ def time_func(log_level: str, name: Optional[str] = None):
             func_name = name or func.__name__
             t1 = time()
             res = func(*args,  **kwargs)
-            print(func_name, res)
             if isawaitable(res):
                 # Ensure we only log once the function completes
                 async def await_result():


### PR DESCRIPTION
We would like to diagnose why startup times on the bridge are so poor, so with that in mind this PR attempts to add a decorator function that times funcs.

This was quite python heavy and my brain is very JS heavy, so feedback much appreciated.